### PR TITLE
Preserve alert delivery method

### DIFF
--- a/lib/galerts/alerts_manager.rb
+++ b/lib/galerts/alerts_manager.rb
@@ -110,7 +110,7 @@ module Galerts
 
 		# Delete the alert and then re-create it
 		def update(alert)
-			delete(alert) && create(alert.query,alert.domain,alert.type,alert.frequency,alert.volume,alert.feed_url.nil?)
+			delete(alert) && create(alert.query,alert.domain,alert.type,alert.frequency,alert.volume,alert.feed)
 		end
 
 		# Delete an alert


### PR DESCRIPTION
There was a bug in the way a Google Alert is updated that would clobber the pre-existing Alert deliver method.

This commit should fix it.
